### PR TITLE
toolbarMenu icons add pull right feature

### DIFF
--- a/examples/custom-toolbar.html
+++ b/examples/custom-toolbar.html
@@ -23,7 +23,7 @@ $(function() {
         height: 640,
         path : '../lib/',
         toolbarIcons : function() {
-            return ["undo", "redo", "|", "bold", "hr", "|", "preview", "watch", "|", "fullscreen", "info", "testIcon", "testIcon2", "file", "faicon"]
+            return ["undo", "redo", "|", "bold", "hr", "|", "info", "testIcon", "testIcon2", "file", "faicon", "||", "watch", "fullscreen", "preview"]
         },
         toolbarIconsClass : {
             testIcon : "fa-gears"  // 指定一个FontAawsome的图标类
@@ -104,7 +104,7 @@ $(function() {
                     path : '../lib/',
                     toolbarIcons : function() {
                         // Or return editormd.toolbarModes[name]; // full, simple, mini
-                        return ["undo", "redo", "|", "bold", "hr", "|", "preview", "watch", "|", "fullscreen", "info", "testIcon", "testIcon2", "file", "faicon"]
+                        return ["undo", "redo", "|", "bold", "hr", "|", "info", "testIcon", "testIcon2", "file", "faicon", "||", "watch", "fullscreen", "preview"]
                     },
                     // toolbarIcons : "full", // You can also use editormd.toolbarModes[name] default list, values: full, simple, mini.
                     toolbarIconsClass : {

--- a/src/editormd.js
+++ b/src/editormd.js
@@ -1043,13 +1043,17 @@
                             : ((typeof settings.toolbarIcons === "string")  ? editormd.toolbarModes[settings.toolbarIcons] : settings.toolbarIcons);
             
             var toolbarMenu = toolbar.find("." + this.classPrefix + "menu"), menu = "";
-            
+
+            var pullRight = false;
             for (var i = 0, len = icons.length; i < len; i++)
             {
                 var name = icons[i];
-                
-                if (name !== "|")
-                {
+
+                if (name === "||") {
+                    pullRight = true;
+                } else if (name === "|") {
+                    menu += "<li class=\"divider\" unselectable=\"on\">|</li>";
+                } else {
                     var isHeader = (/h(\d)/.test(name));
                     var index    = name;
                     
@@ -1065,24 +1069,22 @@
                     iconTexts = (typeof iconTexts === "undefined") ? "" : iconTexts;
                     iconClass = (typeof iconClass === "undefined") ? "" : iconClass;
                     
-                    menu += "<li>";
+                    var menuItem = pullRight ? "<li class=\"pull-right\">" : "<li>";
                     
                     if (typeof settings.toolbarCustomIcons[name] !== "undefined" && typeof settings.toolbarCustomIcons[name] !== "function")
                     {
-                        menu += settings.toolbarCustomIcons[name];
+                        menuItem += settings.toolbarCustomIcons[name];
                     } 
                     else 
-                    {                    
-                        menu += "<a href=\"javascript:;\" title=\"" + title + "\" unselectable=\"on\">" +
+                    {
+                        menuItem += "<a href=\"javascript:;\" title=\"" + title + "\" unselectable=\"on\">" +
                                 "<i class=\"fa " + iconClass + "\" name=\""+name+"\" unselectable=\"on\">"+((isHeader) ? name.toUpperCase() : ( (iconClass === "") ? iconTexts : "") ) + "</i>" +
                                 "</a>";
                     }
-                    
-                    menu += "</li>";
-                }
-                else
-                {
-                    menu += "<li class=\"divider\" unselectable=\"on\">|</li>";
+
+                    menuItem += "</li>";
+
+                    menu = pullRight ? menuItem + menu : menu + menuItem;
                 }
             }
             


### PR DESCRIPTION
#69 

toolbarMenu icons add pull right feature, using "||" as divider