### PR TITLE
修复未实时预览不能全屏预览

### DIFF
--- a/editormd.js
+++ b/editormd.js
@@ -1965,14 +1965,15 @@
         
         save : function() {
             
-            if (timer === null)
+            var _this            = this;
+            var state            = this.state;
+            var settings         = this.settings;
+
+            if (timer === null && !(!settings.watch && state.preview))
             {
                 return this;
             }
             
-            var _this            = this;
-            var state            = this.state;
-            var settings         = this.settings;
             var cm               = this.cm;            
             var cmValue          = cm.getValue();
             var previewContainer = this.previewContainer;


### PR DESCRIPTION
没有开启实时预览的时候，输入新的内容，直接点击全屏预览，会还是旧的数据。