### PR TITLE
修正全屏之后背景内容重叠的问题

### DIFF
--- a/scss/editormd.codemirror.scss
+++ b/scss/editormd.codemirror.scss
@@ -18,6 +18,7 @@
     line-height: 1.6;
     display: none;
     background: #fff;
+    z-index:10;
 }
 
 .editormd {


### PR DESCRIPTION
由于preview没有指定z-index，在全屏之后可能会发生背景内容重叠的现象。