### PR TITLE
修正几个问题

### DIFF
--- a/css/editormd.css
+++ b/css/editormd.css
@@ -4424,6 +4424,7 @@ hr.editormd-page-break {
   left: 0;
   border: none;
   margin: 0 auto;
+  z-index:9999;
 }
 
 /* Editor.md Dark theme */

--- a/editormd.js
+++ b/editormd.js
@@ -415,7 +415,7 @@
             }
             
             var appendElements = [
-                (!settings.readOnly) ? "<a href=\"javascript:;\" class=\"fa fa-close " + classPrefix + "preview-close-btn\"></a>" : "",
+                (!settings.readOnly) ? "<a href=\"javascript:;\" class=\"" + classPrefix + "preview-close-btn\"><i class=\"fa fa-close \"></i> </a>" : "",
                 ( (settings.saveHTMLToTextarea) ? "<textarea class=\"" + classNames.textarea.html + "\" name=\"" + id + "-html-code\"></textarea>" : "" ),
                 "<div class=\"" + classPrefix + "preview\"><div class=\"markdown-body " + classPrefix + "preview-container\"></div></div>",
                 "<div class=\"" + classPrefix + "container-mask\" style=\"display:block;\"></div>",

--- a/editormd.js
+++ b/editormd.js
@@ -1071,12 +1071,12 @@
                     return false;
                 }
 
-                if (top - editor.offset().top > 10 && top < editor.height())
+                if (top - editor.offset().top > 10 && top - editor.offset().top < editor.height() - toolbar.height())
                 {
                     toolbar.css({
                         position : "fixed",
                         width    : editor.width() + "px",
-                        left     : ($window.width() - editor.width()) / 2 + "px"
+                        left     : editor.offset().left + "px"
                     });
                 }
                 else


### PR DESCRIPTION
一、当页面往下滚动，工具条自动固定到顶端时的问题：
1、如果编辑器在页面上的位置不是水平居中，则工具条固定到页面顶端时位置不对。
2、如果用户将页面往下滚，则应该是当编辑器的编辑区域看不见的时候，去掉工具条的置顶。
二、全屏模式时的问题：
1、如果页面上有其他浮动元素，则全屏时，这些浮动元素会显示到编辑器的上层。
三、  修正编辑器右上角在非预览状态时显示一个X号图标的问题。
我这边在使用这个编辑器的时候，非预览状态，编辑器右上角会显示一个X号。
究其原因，editormd-preview-close-btn有display:none属性，fa和fa-有display:inline-block属性，二者有冲突。
在我这边的使用环境下，会使display:inline-block优先。

.min.js和.min.css我都没修改。
