### PR TITLE
previewContainer.find(...).flowChart调用报错

### DIFF
--- a/editormd.js
+++ b/editormd.js
@@ -1529,11 +1529,15 @@
                     return this;
                 }
                 
-                previewContainer.find(".flowchart").flowChart(); 
+                previewContainer.find(".flowchart")
+                   && previewContainer.find(".flowchart").length > 0
+                   && previewContainer.find(".flowchart").flowChart();
             }
 
             if (settings.sequenceDiagram) {
-                previewContainer.find(".sequence-diagram").sequenceDiagram({theme: "simple"});
+                previewContainer.find(".sequence-diagram")
+                    && previewContainer.find(".sequence-diagram").length > 0
+                    && previewContainer.find(".sequence-diagram").sequenceDiagram({theme: "simple"});
             }
                     
             var preview    = $this.preview;


### PR DESCRIPTION
当我创建一个不包含任何内容的编辑器的时候回报这个错误：
`Uncaught TypeError: previewContainer.find(...).flowChart is not a function`
看错误信息应该是编辑器输入框内没有`flowchart`和`sequence-diagram`这两个图表样式的导致找不到而出错。