### PR TITLE
fixed a bug on convert to html text

### DIFF
--- a/editormd.js
+++ b/editormd.js
@@ -3577,8 +3577,7 @@
             markdownToC.push(toc);
             
             var headingHTML = "<h" + level + " id=\"h"+ level + "-" + this.options.headerPrefix + id +"\">";
-            
-            headingHTML    += "<a name=\"" + text + "\" class=\"reference-link\"></a>";
+            headingHTML    += "<a name=\"" + text.replace(/<[^>]*>\s?/g,'') + "\" class=\"reference-link\"></a>";
             headingHTML    += "<span class=\"header-link octicon octicon-link\"></span>";
             headingHTML    += (hasLinkReg) ? this.atLink(this.emoji(linkText)) : this.atLink(this.emoji(text));
             headingHTML    += "</h" + level + ">";


### PR DESCRIPTION
The bug is:
If you paste a line like:
```
#### <i class="icon-file"></i> Document
```
to the "Full example" [page](https://pandao.github.io/editor.md/), the html will be shown like
```
Document" class="reference-link"> Document
```
