### PR TITLE
Plugins localization

### DIFF
--- a/examples/php/editormd.uploader.class.php
+++ b/examples/php/editormd.uploader.class.php
@@ -252,7 +252,7 @@
         
          private function setSeveName()
          {             
-            $this->saveName = $this->randomFileName();
+            $this->saveName = $this->randomFileName().".".$this->fileExt;
              
             if($this->saveName == '') //如果没生成随机文件名，就保留原文件名
             {

--- a/languages/en.js
+++ b/languages/en.js
@@ -77,7 +77,8 @@
                 },
                 preformattedText : {
                     title             : "Preformatted text / Codes", 
-                    emptyAlert        : "Error: Please fill in the Preformatted text or content of the codes."
+                    emptyAlert        : "Error: Please fill in the Preformatted text or content of the codes.",
+                    placeholder       : "coding now...."
                 },
                 codeBlock : {
                     title             : "Code block",         
@@ -85,7 +86,8 @@
                     selectDefaultText : "select a code language...",
                     otherLanguage     : "Other languages",
                     unselectedLanguageAlert : "Error: Please select the code language.",
-                    codeEmptyAlert    : "Error: Please fill in the code content."
+                    codeEmptyAlert    : "Error: Please fill in the code content.",
+                    placeholder       : "coding now...."
                 },
                 htmlEntities : {
                     title : "HTML Entities"

--- a/languages/zh-tw.js
+++ b/languages/zh-tw.js
@@ -77,7 +77,8 @@
                 },
                 preformattedText : {
                     title             : "添加預格式文本或代碼塊", 
-                    emptyAlert        : "錯誤：請填寫預格式文本或代碼的內容。"
+                    emptyAlert        : "錯誤：請填寫預格式文本或代碼的內容。",
+                    placeholder       : "coding now...."
                 },
                 codeBlock : {
                     title             : "添加代碼塊",                 
@@ -85,7 +86,8 @@
                     selectDefaultText : "請語言代碼語言",
                     otherLanguage     : "其他語言",
                     unselectedLanguageAlert : "錯誤：請選擇代碼所屬的語言類型。",
-                    codeEmptyAlert    : "錯誤：請填寫代碼內容。"
+                    codeEmptyAlert    : "錯誤：請填寫代碼內容。",
+                    placeholder:      : "coding now...."
                 },
                 htmlEntities : {
                     title : "HTML實體字符"

--- a/plugins/code-block-dialog/code-block-dialog.js
+++ b/plugins/code-block-dialog/code-block-dialog.js
@@ -85,7 +85,7 @@
                 var dialogHTML = "<div class=\"" + classPrefix + "code-toolbar\">" +
                                         dialogLang.selectLabel + "<select><option selected=\"selected\" value=\"\">" + dialogLang.selectDefaultText + "</option></select>" +
                                     "</div>" +
-                                    "<textarea placeholder=\"coding now....\" style=\"display:none;\">" + selection + "</textarea>";
+                                    "<textarea placeholder=\"" + dialogLang.placeholder + "\" style=\"display:none;\">" + selection + "</textarea>";
 
                 dialog = this.createDialog({
                     name   : dialogName,

--- a/plugins/preformatted-text-dialog/preformatted-text-dialog.js
+++ b/plugins/preformatted-text-dialog/preformatted-text-dialog.js
@@ -41,7 +41,7 @@
             }
             else 
             {      
-                var dialogContent = "<textarea placeholder=\"coding now....\" style=\"display:none;\">" + selection + "</textarea>";
+                var dialogContent = "<textarea placeholder=\"" + dialogLang.placeholder + "\" style=\"display:none;\">" + selection + "</textarea>";
 
                 dialog = this.createDialog({
                     name   : dialogName,


### PR DESCRIPTION
This is related to the issue #555 . I found that the placeholder is hard coded and the only way to translate it is to modify the source code. I need to translate everything, so I decided to make these parts localisable by adding corresponding keys to the languages files. Note that I intentionally did not translate the label added to the zh-tw.js file. Otherwise this change will affect existing projects.