### PR TITLE
Handle two editors with different toolbars on the same page

### DIFF
--- a/editormd.js
+++ b/editormd.js
@@ -365,7 +365,7 @@
             
             var _this            = this;
             var classPrefix      = this.classPrefix  = editormd.classPrefix; 
-            var settings         = this.settings     = $.extend(true, editormd.defaults, options);
+            var settings         = this.settings     = $.extend(true, {}, editormd.defaults, options);
             
             id                   = (typeof id === "object") ? settings.id : id;
             


### PR DESCRIPTION
Right now, if you try to include two editors on the same page with different toolbars, there's a race condition, and most of the time the two editors end up with the same toolbar. This is due to both trying to extend editormd.defaults instead of getting their own independent settings ; can be fixed easily.

Test code would be something like

```
function bindFirst() {
  editormd('area1-field', {
    path: 'libraries/editor.md/lib/',
    toolbarIcons: function() {
      return ['bold', 'italic', 'underline'];
    },
    width: '75%'
  });
}
function bindSecond() {
  editormd('area2-field', {
    path: 'libraries/editor.md/lib/',
    toolbarIcons: function() {
      return ['undo', 'redo'];
    },
    width: '75%'
  });
}
jQuery(function() {
  bindFirst();
  bindSecond();
});
```