### PR TITLE
修复没有填写图片描述光标位置不正确的问题

### DIFF
--- a/plugins/image-dialog/image-dialog.js
+++ b/plugins/image-dialog/image-dialog.js
@@ -102,9 +102,9 @@
                                 cm.replaceSelection("[![" + alt + "](" + url + altAttr + ")](" + link + altAttr + ")");
                             }
 
-                            if (alt === "") {
-                                cm.setCursor(cursor.line, cursor.ch + 2);
-                            }
+                            // if (alt === "") {
+                            //     cm.setCursor(cursor.line, cursor.ch + 2);
+                            // }
 
                             this.hide().lockScreen(false).hideMask();
 


### PR DESCRIPTION
现在如果上传图片没有填写图片描述的话，光标始终会第二行或者第三行，而不是在我原先要输入的地方

不太知道作者原意图是什么？是否要改一下呢？目前我都是注释掉这两行，请看一下，是否改正确，还是有别的我没有想到的地方，感谢。