### PR TITLE
Fix string pass to marked

### DIFF
--- a/editormd.js
+++ b/editormd.js
@@ -3957,7 +3957,7 @@
             smartypants : true
         };
         
-		markdownDoc = new String(markdownDoc);
+	markdownDoc = new String(markdownDoc).toString();
         
         var markdownParsed = marked(markdownDoc, markedOptions);
         


### PR DESCRIPTION
marked only accept string type, `new String()` will return an object `[object String]`

https://github.com/markedjs/marked/blob/f35c3e6d9a22980c9a5b61d33c394b4429914803/lib/marked.js#L1549-L1557