### PR TITLE
修复解析HTML过滤标签中XSS注入问题

### DIFF
--- a/editormd.js
+++ b/editormd.js
@@ -3798,7 +3798,7 @@
         return tocMenus;
     };
     
-    /**
+    /** 
      * 简单地过滤指定的HTML标签
      * Filter custom html tags
      * 


### PR DESCRIPTION
在使用editor.md时发现，HTML过滤中存在XSS注入问题。
与issues: 
#1018 #985 #916 #890 #861 等 `is:issue state:open xss`
遇到的问题一致。
在对于嵌入式前端编辑/展示，或存储在数据库中是极为危险的XSS漏洞。
# 原本过滤规则

原本使用的过滤规则为：
```
htmlDecode: "style,script,iframe,object,embed|on*",
```
 - 在原状态下仅能过滤掉非自闭合标签，如`<a href="x" onclick=eval("alert('xss');")>xss</a>`
 - 面对自闭合标签将无法进行过滤，如`<img src=x onerror="alert(1)"/>`
 - 面对XSS绕过更是无法进行过滤，如编码绕过等(文末将展示大部分常见XSS注入)
 - 过滤规则无法支持多个通配符与单值，且需要严格定义(不能缺省)

# 修改后过滤规则

 - 将过滤匹配部分改为了对标签头进行匹配，可以支持自闭合 / 非自闭合标签。
 - 增加对属性名与属性值的过滤匹配，解决无法使用多个通配符或与单值作过滤规则
 - 增加对HTML实体解码，过滤编码绕过
 - 修改对过滤规则的拆分，与兼容缺省，修改为`标签|属性名|属性值`，其中属性名、属性值支持通配符
 - 对触发过滤规则的标签转义为文本

推荐使用的过滤规则为：
```
htmlDecode: "style,script,iframe,object,embed|on*|javascript,base64,data:",
```
!!注意：过度过滤会使原有的md标签被过滤

# 常见XSS样本

参考：https://www.freebuf.com/articles/web/340080.html

修复后：
(使用推荐的过滤规则)
<img width="1920" height="899" alt="image" src="https://github.com/user-attachments/assets/2ce72bc4-3cc6-4cb3-976d-5b287895ac73" />
